### PR TITLE
fixes #10

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -28,5 +28,5 @@ Bundle Of Traits is a mod that adds 15 new traits designed with special mechanic
 Read More on GitHub: https://github.com/Danimineiro/BucketOfTraits#readme
 	</description>
 	<url>https://github.com/Danimineiro/BucketOfTraits</url>
-	<modVersion IgnoreIfNoMatchingField="True">3.0.1</modVersion>
+	<modVersion IgnoreIfNoMatchingField="True">3.0.2</modVersion>
 </ModMetaData>

--- a/Source/[DN] BOT 1.5/ThinkNodes/BOT_JobGiverFleeing.cs
+++ b/Source/[DN] BOT 1.5/ThinkNodes/BOT_JobGiverFleeing.cs
@@ -36,6 +36,8 @@ namespace More_Traits.ThinkNodes
 
         protected override Job TryGiveJob(Pawn pawn)
         {
+            if (!pawn.Spawned) return null;
+
             List<TraitDef> fleeTraits = GetTraits(pawn, out bool ignoreDrafted);
             int traitCount = fleeTraits.Count;
 


### PR DESCRIPTION
check if a pawn is spawned before trying to make them flee from danger